### PR TITLE
Move avatar menu to CS50 menu

### DIFF
--- a/simple.js
+++ b/simple.js
@@ -694,6 +694,9 @@ define(function(require, exports, module) {
          * Sets the initial icon in the avatar menu toolbar
          */
         function setIcon(err, user) {
+            if (!user || !user.hasOwnProperty("id"))
+                return;
+
             var currentMenu = menus.get("user_" + user.id);
 
             // If offline IDE, return


### PR DESCRIPTION
This should move the avatar menu on online IDEs to the CS50 IDE menu, underneath the Preferences button. This will also remove the "Go To Your Dashboard" button, as it is now in the avatar menu. It will hide the avatar menu, and finally make sure that none of this happens on an offline IDE.
