### PR TITLE
added lines to suppress warning message

### DIFF
--- a/simple.js
+++ b/simple.js
@@ -492,8 +492,9 @@ define(function(require, exports, module) {
                             var prevData = clipboard.clipboardData.getData("text/plain");
 
                             // Set the variable updateCommand to be the command that updates the terminal
-                            // Copy to the clipboard the data stored in updateCommand
                             var updateCommand = " source /etc/profile && source /home/ubuntu/.bashrc\n";
+
+                            // Copy to the clipboard the data stored in updateCommand
                             clipboard.clipboardData.setData("text/plain", updateCommand);
 
                             // Pastes in the active Tab (the terminal) the command stored in the clipboard


### PR DESCRIPTION
Changed to callback function in lines 494-498 + 504-507 to prevent `source /etc/profile && source /home/ubuntu/.bashrc` from appearing in terminal history. Can be changed back easily if unnecessary. 
