### PR TITLE
Tweak UI

### DIFF
--- a/simple.js
+++ b/simple.js
@@ -102,7 +102,6 @@ define(function(require, exports, module) {
          * Toggles simplification of the menus at the top of Cloud 9
          */
         function toggleMenus(lessComfortable) {
-
             // remove gear icon as redundant from both modes
             var bar = layout.findParent({name: "preferences"});
             if (bar.childNodes) {
@@ -880,11 +879,10 @@ define(function(require, exports, module) {
         }
 
         function getMenuItem(path) {
-            if (menus.get(path) !== null){
-                return menus.get(path).item;
-            } else {
-                return null;
-            }
+            var menu = menus.get(path);
+            if (menu && menu.item)
+                return menu.item;
+            return null;
         }
 
         function moveMenuItem(currentPath, newPath, newLocation) {


### PR DESCRIPTION
This changes "Goto Symbol" to "Symbol" in Less Comfortable Mode. This also rearranges the "File/New From Template" menu to be in alphabetical order in both Less Comfortable and More Comfortable Mode. It removes the word "file" from the templates in Less Comfortable Mode.

A new function was made because it can't be added to one of the toggleSimpleMode function. I suspect this is because when adding it to one of those functions, the menu is looking for one of the hidden items and trying to place an item before it leading to messages similar to: "insertBefore of null is invalid".
