### PR TITLE
matches terminal's tooltip with its title

### DIFF
--- a/simple.js
+++ b/simple.js
@@ -651,6 +651,9 @@ define(function(require, exports, module) {
                         docList.forEach(function(doc) {
                             if (doc.hasOwnProperty("title"))
                                 doc.title = title;
+
+                            if (doc.hasOwnProperty("tooltip"))
+                                doc.tooltip = title;
                         });
                     }
                 }, plugin);


### PR DESCRIPTION
Before:
![tooltip-before](https://cloud.githubusercontent.com/assets/7230211/21111688/5fd5ae36-c0ab-11e6-93cb-e1db69bf3428.png)

After:
![tooltip-after](https://cloud.githubusercontent.com/assets/7230211/21111692/62e4786e-c0ab-11e6-89a1-e825a88b1007.png)

