### PR TITLE
moved menu items

### DIFF
--- a/simple.js
+++ b/simple.js
@@ -211,7 +211,7 @@ define(function(require, exports, module) {
 
             // add Language to View menu
             menus.addItemByPath("View/~", new ui.divider(), 3, plugin);
-            menus.addItemByPath("View/Languages", languagesItem, 4, plugin);
+            menus.addItemByPath("View/Language", languagesItem, 4, plugin);
 
             // fetch current language from settings or fallback to English
             var currLanguage = settings.get("project/cs50/simple/@language") || "en";

--- a/simple.js
+++ b/simple.js
@@ -888,12 +888,7 @@ define(function(require, exports, module) {
                 "Tools",
 
                 // Window menu
-                "Window/New Immediate Window",
-                "Window/Installer...",
-                "Window/Navigate",
-                "Window/Commands",
-                "Window/Presets",
-                "Window/Changes",
+                "Window",
 
                 // Support menu
                 "Support",

--- a/simple.js
+++ b/simple.js
@@ -469,14 +469,6 @@ define(function(require, exports, module) {
                 }
             }), 0, plugin);
 
-            // add "What's New?"
-            menus.addItemByPath("Cloud9/What's New?", new ui.item({
-                caption: "What's New?",
-                onclick: function() {
-                    window.open("http://docs.cs50.net/ide/new.html", "_blank");
-                }
-            }), 1, plugin);
-
             // add divider before "About Cloud9"
             menus.addItemByPath("Cloud9/~", new ui.divider(), 50, plugin);
 

--- a/simple.js
+++ b/simple.js
@@ -484,7 +484,9 @@ define(function(require, exports, module) {
                         "created it. Your files and folders will not be deleted.",
                         // OK
                         function() {
-                            window.location.search += "&reset=1";
+
+                            // reset user, state, and project settings
+                            window.location.search += "&reset=user|state|project";
                         },
 
                         // Cancel
@@ -492,9 +494,6 @@ define(function(require, exports, module) {
                     );
                 }
             }), 302, plugin);
-
-            // cache divider to show in more-comfy
-            divs.push(div);
 
             // hide "Restart Cloud9"
             setMenuVisibility("Cloud9/Restart Cloud9", false);

--- a/simple.js
+++ b/simple.js
@@ -578,6 +578,34 @@ define(function(require, exports, module) {
         }
 
         /**
+         * Moves some menu items from their original menus to different menus.
+         */
+        function moveMenuItems() {
+
+            // move Collaborate, Outline, and Share from Window to View
+            ["Collaborate", "Outline", "Share..."].forEach(function(caption) {
+
+                // get menu item
+                var item = menus.get("Window/" + caption).item;
+                var index = 800;
+                if (item) {
+
+                    // remove trailing ... from caption if exists
+                    if (caption.endsWith("...")) {
+                        caption = caption.substring(0, caption.length - 3);
+                        item.setAttribute("caption", caption);
+                    }
+
+                    // move to View menu
+                    menus.addItemByPath("View/" + caption, item, index += 10, plugin);
+                }
+
+                // add divider before View/Layout
+                menus.addItemByPath("View/~", new ui.divider(), index += 10, plugin);
+            });
+        }
+
+        /**
          * Sets and exports LANGUAGE env var in ~/.cs50/language
          */
         function setLanguage(language) {
@@ -1362,6 +1390,7 @@ define(function(require, exports, module) {
             customizeC9Menu();
             hideElements();
             hideGearIcon();
+            moveMenuItems();
             setTitleFromTabs();
             updateFontSize();
             updateMenuCaptions();

--- a/simple.js
+++ b/simple.js
@@ -477,7 +477,7 @@ define(function(require, exports, module) {
             menus.addItemByPath("Cloud9/Reset Settings", new ui.item({
                 caption: "Reset Settings",
                 onclick: function() {
-                    confirm("Reset settings",
+                    confirm("Reset Settings",
                         "",
                         "Are you sure you want to reset CS50 IDE to factory " +
                         "defaults? It will then look just as it did when you " +
@@ -672,7 +672,7 @@ define(function(require, exports, module) {
                     // remember chosen language
                     settings.set("project/cs50/simple/@language", language);
 
-                    confirm("Language updated",
+                    confirm("Language Updated",
                         "Restart terminal window" + (count == 2 ? "s" : "") + "?",
                         (count === 2)
                             ? "Doing so will kill any programs that are running in open terminal windows."

--- a/simple.js
+++ b/simple.js
@@ -56,7 +56,6 @@ define(function(require, exports, module) {
 
         var libterm = require("plugins/c9.ide.terminal/aceterm/libterm").prototype;
 
-        var areaBars = [];
         var authorInfoToggled = null;
         var avatar = null;
         var dark = null;
@@ -500,27 +499,24 @@ define(function(require, exports, module) {
         }
 
         /**
-         * Finds bars for left and right areas and caches original context menu
-         * handlers to disable context menu in less-comfy mode
+         * Finds bars for left and right areas and disables their context menus
          */
-        function findAreaBars() {
+        function disableAreaBarsMenu() {
 
             // find bars for left and right panel areas
             [panels.areas["left"], panels.areas["right"]].forEach(function(area) {
                 if (area && area.aml && area.aml.childNodes.length > 0) {
-                    area.aml.childNodes.some(function(child) {
-                        if (child.$baseCSSname === "panelsbar") {
+                    area.aml.childNodes.some(function(bar) {
+                        if (bar.$baseCSSname === "panelsbar") {
 
-                            // remember original context menu handler
-                            child.originaloncontextmenu = child.oncontextmenu;
-
-                            // remember bar
-                            areaBars.push(child);
+                            // disable context menu
+                            bar.oncontextmenu = function() {};
                         }
                     });
                 }
             });
         }
+
         /**
          * Hides the given div by changing CSS
          *
@@ -851,15 +847,6 @@ define(function(require, exports, module) {
         }
 
         /**
-         * Toggles context menu for right and left areas
-         */
-        function toggleAreaMenu(enabled) {
-            areaBars.forEach(function(bar) {
-                bar.oncontextmenu = enabled ? bar.originaloncontextmenu : function() {};
-            });
-        }
-
-        /**
          * Disable code folding
          *
          */
@@ -902,7 +889,7 @@ define(function(require, exports, module) {
         }
 
         /**
-         * Toggles simplification of the menus at the top of Cloud 9
+         * Simplifies menus at the top of Cloud9
          */
         function hideMenus() {
             // hide each menu item
@@ -1434,7 +1421,7 @@ define(function(require, exports, module) {
             addTreeToggles();
             addTooltips();
             customizeC9Menu();
-            findAreaBars();
+            disableAreaBarsMenu();
             hideElements();
             hideGearIcon();
             moveMenuItems();
@@ -1599,7 +1586,6 @@ define(function(require, exports, module) {
         plugin.on("unload", function() {
             // TODO unload correctly
             // toggleSimpleMode(false);
-            areaBars = [];
             authorInfoToggled = null;
             avatar = null;
             dark = null;

--- a/simple.js
+++ b/simple.js
@@ -56,6 +56,7 @@ define(function(require, exports, module) {
 
         var libterm = require("plugins/c9.ide.terminal/aceterm/libterm").prototype;
 
+        var areaBars = [];
         var authorInfoToggled = null;
         var avatar = null;
         var dark = null;
@@ -488,6 +489,28 @@ define(function(require, exports, module) {
         }
 
         /**
+         * Finds bars for left and right areas and caches original context menu
+         * handlers to disable context menu in less-comfy mode
+         */
+        function findAreaBars() {
+
+            // find bars for left and right panel areas
+            [panels.areas["left"], panels.areas["right"]].forEach(function(area) {
+                if (area && area.aml && area.aml.childNodes.length > 0) {
+                    area.aml.childNodes.some(function(child) {
+                        if (child.$baseCSSname === "panelsbar") {
+
+                            // remember original context menu handler
+                            child.originaloncontextmenu = child.oncontextmenu;
+
+                            // remember bar
+                            areaBars.push(child);
+                        }
+                    });
+                }
+            });
+        }
+        /**
          * Hides the given div by changing CSS
          *
          * @param {AMLElement} the AMLElement to hide
@@ -815,6 +838,15 @@ define(function(require, exports, module) {
                 // update style of tree-toggle button
                 treeToggles.button.setAttribute("class", style);
             }
+        }
+
+        /**
+         * Toggles context menu for right and left areas
+         */
+        function toggleAreaMenu(enabled) {
+            areaBars.forEach(function(bar) {
+                bar.oncontextmenu = enabled ? bar.originaloncontextmenu : function() {};
+            });
         }
 
         /**
@@ -1388,6 +1420,7 @@ define(function(require, exports, module) {
             addTreeToggles();
             addTooltips();
             customizeC9Menu();
+            findAreaBars();
             hideElements();
             hideGearIcon();
             moveMenuItems();
@@ -1552,6 +1585,7 @@ define(function(require, exports, module) {
         plugin.on("unload", function() {
             // TODO unload correctly
             // toggleSimpleMode(false);
+            areaBars = [];
             authorInfoToggled = null;
             avatar = null;
             dark = null;

--- a/simple.js
+++ b/simple.js
@@ -612,6 +612,11 @@ define(function(require, exports, module) {
                 // add divider before View/Layout
                 menus.addItemByPath("View/~", new ui.divider(), index += 10, plugin);
             });
+
+            // move New Terminal to File menu
+            var newTerminal = menus.get("Window/New Terminal").item;
+            if (newTerminal)
+                menus.addItemByPath("File/New Terminal", newTerminal, 150, plugin);
         }
 
         /**

--- a/simple.js
+++ b/simple.js
@@ -444,9 +444,6 @@ define(function(require, exports, module) {
                         });
                     }
                 });
-
-                // CS50 IDE > Restart Workspace to CS50 IDE > Restart
-                setMenuCaption("Cloud9/Restart Workspace", "Restart");
             }
             else {
                 // remove "Dashboard" offline
@@ -475,6 +472,29 @@ define(function(require, exports, module) {
             // add divider after "Preferences"
             var div = new ui.divider();
             menus.addItemByPath("Cloud9/~", div, 301, plugin);
+
+            // add "Reset"
+            menus.addItemByPath("Cloud9/Reset Settings", new ui.item({
+                caption: "Reset Settings",
+                onclick: function() {
+                    confirm("Reset settings",
+                        "",
+                        "Are you sure you want to reset CS50 IDE to factory " +
+                        "defaults? It will then look just as it did when you " +
+                        "created it. Your files and folders will not be deleted.",
+                        // OK
+                        function() {
+                            window.location.search += "&reset=1";
+                        },
+
+                        // Cancel
+                        function() {}
+                    );
+                }
+            }), 302, plugin);
+
+            // cache divider to show in more-comfy
+            divs.push(div);
 
             // hide "Restart Cloud9"
             setMenuVisibility("Cloud9/Restart Cloud9", false);

--- a/simple.js
+++ b/simple.js
@@ -204,7 +204,7 @@ define(function(require, exports, module) {
 
             // create Language submenu
             var languagesItem = new MenuItem({
-                caption: "Languages",
+                caption: "Language",
                 submenu: new Menu({}, plugin)
             });
 
@@ -226,7 +226,7 @@ define(function(require, exports, module) {
                 });
 
                 item.aml.setAttribute("selected", language === currLanguage);
-                menus.addItemByPath("View/Languages/" + language, item, plugin);
+                menus.addItemByPath("View/Language/" + language, item, plugin);
             });
 
         }

--- a/simple.js
+++ b/simple.js
@@ -924,6 +924,9 @@ define(function(require, exports, module) {
                 "View/Syntax",
                 "View/Wrap Lines",
                 "View/Wrap To Print Margin",
+                "View/Status Bar",
+                "View/Menu Bar",
+                "View/Tab Buttons",
 
                 // Goto menu
                 "Goto/Goto Anything...",

--- a/simple.js
+++ b/simple.js
@@ -1219,7 +1219,8 @@ define(function(require, exports, module) {
                 "Goto/Goto Symbol...": "Symbol...",
                 "Goto/Goto Command...": "Command...",
                 "Support/Check Cloud9 Status": "Cloud9 Status",
-                "Support/Read Documentation": "Cloud9 Documentation"
+                "Support/Read Documentation": "Cloud9 Documentation",
+                "View/Gutter": "Line Numbers"
             };
 
             // update captions

--- a/simple.js
+++ b/simple.js
@@ -606,18 +606,12 @@ define(function(require, exports, module) {
         function moveMenuItems() {
 
             // move Collaborate, Outline, and Share from Window to View
-            ["Collaborate", "Outline", "Share..."].forEach(function(caption) {
+            ["Collaborate", "Outline"].forEach(function(caption) {
 
                 // get menu item
                 var item = menus.get("Window/" + caption).item;
                 var index = 800;
                 if (item) {
-
-                    // remove trailing ... from caption if exists
-                    if (caption.endsWith("...")) {
-                        caption = caption.substring(0, caption.length - 3);
-                        item.setAttribute("caption", caption);
-                    }
 
                     // move to View menu
                     menus.addItemByPath("View/" + caption, item, index += 10, plugin);


### PR DESCRIPTION
Addresses https://github.com/cs50/ide50/issues/90.

![view](https://user-images.githubusercontent.com/7230211/29326993-9ce5887e-81bb-11e7-9464-f4df41fb17f0.png)
![window](https://user-images.githubusercontent.com/7230211/29326992-9ce2343a-81bb-11e7-8b9a-40101023e47f.png)

Just a couple of questions, do we indeed want to move **New Terminal** under **New From Template** as opposed to just directly under **File**? Also **View > Share** (previously **Window > Share**) doesn't really toggle visibility of a button or a pane. Might it make more sense to keep as is (under **Window**) or remove altogether since **Share** button is on the top-right corner anyway?