### PR TITLE
updating tab tooltip

### DIFF
--- a/simple.js
+++ b/simple.js
@@ -1637,6 +1637,18 @@ define(function(require, exports, module) {
             });
         }
 
+
+        /**
+         * Updates tab tooltip to start with ~/workspace instead of /
+         */
+        function updateTooltip(e) {
+            if (e.tab.path && e.tab.tooltip === e.tab.path && e.tab.tooltip.startsWith("/")) {
+                e.tab.document.tooltip = e.tab.tooltip =
+                    `${c9.workspaceDir.replace(c9.home, "~")}${e.tab.tooltip}`;
+            }
+        }
+
+
         var loaded = false;
         function load() {
 
@@ -1741,12 +1753,19 @@ define(function(require, exports, module) {
             simplifyStatusbar();
 
             // stop marking undeclared variables for javascript files
-            tabs.on("tabAfterActivate", toggleUndeclaredVars);
+            tabs.on("tabAfterActivate", (e) => {
+                toggleUndeclaredVars(e);
+
+                // prevent other plugins from restting it
+                updateTooltip(e);
+            });
 
             // set titles of terminal tabs to current directory name
             tabs.on("tabCreate", function(e) {
                 setTmuxTitle(e.tab);
+                updateTooltip(e);
             }, plugin);
+
 
             // add terminal sound
             terminalSound = new Audio(options.staticPrefix + "/sounds/bell.mp3");

--- a/simple.js
+++ b/simple.js
@@ -1756,7 +1756,7 @@ define(function(require, exports, module) {
             tabs.on("tabAfterActivate", (e) => {
                 toggleUndeclaredVars(e);
 
-                // prevent other plugins from restting it
+                // prevent other plugins from resetting it
                 updateTooltip(e);
             });
 


### PR DESCRIPTION
Since the tooltip has to be set somewhere else first, if a user hovers over a tab button fast enough they might still see the old tooltip that starts with a `/` instead of `~/workspace`. If they move the mouse out and in again they should be the updated tooltip so this might not be exactly the behavior that we want but I couldn't find a way to avoid.

![screenshot from 2018-08-21 09-07-18](https://user-images.githubusercontent.com/7230211/44403164-b856cc00-a521-11e8-85a0-9a6b197765d5.png)
